### PR TITLE
Symbol “$” removed from all currencies other then USD

### DIFF
--- a/dataModule/src/main/java/com/aneonex/bitcoinchecker/datamodule/model/currency/CurrencySymbols.kt
+++ b/dataModule/src/main/java/com/aneonex/bitcoinchecker/datamodule/model/currency/CurrencySymbols.kt
@@ -15,13 +15,13 @@ object CurrencySymbols {
         CURRENCY_SYMBOLS[Currency.CHF] = "Fr"
         CURRENCY_SYMBOLS[Currency.RUB] = "₽"
         CURRENCY_SYMBOLS[Currency.RUR] = "₽"
-        CURRENCY_SYMBOLS[Currency.AUD] = "$"
+//        CURRENCY_SYMBOLS[Currency.AUD] = "$"
         CURRENCY_SYMBOLS[Currency.SEK] = "kr"
         CURRENCY_SYMBOLS[Currency.DKK] = "kr"
-        CURRENCY_SYMBOLS[Currency.HKD] = "$"
-        CURRENCY_SYMBOLS[Currency.SGD] = "$"
+//        CURRENCY_SYMBOLS[Currency.HKD] = "$"
+//        CURRENCY_SYMBOLS[Currency.SGD] = "$"
         CURRENCY_SYMBOLS[Currency.THB] = "฿"
-        CURRENCY_SYMBOLS[Currency.NZD] = "$"
+//        CURRENCY_SYMBOLS[Currency.NZD] = "$"
         CURRENCY_SYMBOLS[Currency.JPY] = "¥"
         CURRENCY_SYMBOLS[Currency.BRL] = "R$"
         CURRENCY_SYMBOLS[Currency.KRW] = "₩"
@@ -33,18 +33,18 @@ object CurrencySymbols {
         CURRENCY_SYMBOLS[Currency.AMD] = "֏"
         CURRENCY_SYMBOLS[Currency.AWG] = "ƒ"
         CURRENCY_SYMBOLS[Currency.AZN] = "m"
-        CURRENCY_SYMBOLS[Currency.BSD] = "$"
+//        CURRENCY_SYMBOLS[Currency.BSD] = "$"
         CURRENCY_SYMBOLS[Currency.BHD] = "ب.د"
         CURRENCY_SYMBOLS[Currency.BDT] = "৳"
-        CURRENCY_SYMBOLS[Currency.BBD] = "$"
+//        CURRENCY_SYMBOLS[Currency.BBD] = "$"
         CURRENCY_SYMBOLS[Currency.BYR] = "Br"
-        CURRENCY_SYMBOLS[Currency.BZD] = "$"
-        CURRENCY_SYMBOLS[Currency.BMD] = "$"
+//        CURRENCY_SYMBOLS[Currency.BZD] = "$"
+//        CURRENCY_SYMBOLS[Currency.BMD] = "$"
         CURRENCY_SYMBOLS[Currency.BTN] = "Nu."
         CURRENCY_SYMBOLS[Currency.BOB] = "Bs."
         CURRENCY_SYMBOLS[Currency.BAM] = "КМ"
         CURRENCY_SYMBOLS[Currency.BWP] = "P"
-        CURRENCY_SYMBOLS[Currency.BND] = "$"
+//        CURRENCY_SYMBOLS[Currency.BND] = "$"
         CURRENCY_SYMBOLS[Currency.BGN] = "лв"
         CURRENCY_SYMBOLS[Currency.BIF] = "Fr"
         CURRENCY_SYMBOLS[Currency.TRY] = "TL"
@@ -78,10 +78,5 @@ object CurrencySymbols {
 //        CURRENCY_SYMBOLS[Currency.UAH] = "₴"
         CURRENCY_SYMBOLS[Currency.PHP] = "₱"
         CURRENCY_SYMBOLS[Currency.CZK] = "Kč"
-
-
-
-
-
     }
 }


### PR DESCRIPTION
To avoid confusion with global USD