### PR TITLE
Refactored Uniswap and DEX support (now using TheGraph.com service)

### DIFF
--- a/dataModule/src/main/java/com/aneonex/bitcoinchecker/datamodule/model/Market.kt
+++ b/dataModule/src/main/java/com/aneonex/bitcoinchecker/datamodule/model/Market.kt
@@ -25,6 +25,13 @@ abstract class Market(
     }
 
     abstract fun getUrl(requestId: Int, checkerInfo: CheckerInfo): String
+
+    // When the body is set, the HTTP POST request is used
+    // By default is HTTP GET
+    open fun getRequestBody(requestId: Int, checkerInfo: CheckerInfo): String? {
+        return null
+    }
+
     @Throws(Exception::class)
     fun parseTickerMain(requestId: Int, responseString: String, ticker: Ticker, checkerInfo: CheckerInfo): Ticker {
         parseTicker(requestId, responseString, ticker, checkerInfo)
@@ -67,6 +74,11 @@ abstract class Market(
         get() = 1
 
     open fun getCurrencyPairsUrl(requestId: Int): String? {
+        return null
+    }
+
+    // If body defined than used HTTP POST request
+    open fun getCurrencyPairsRequestBody(requestId: Int): String? {
         return null
     }
 

--- a/dataModule/src/main/res/values/market_cautions.xml
+++ b/dataModule/src/main/res/values/market_cautions.xml
@@ -5,7 +5,8 @@
     <string name="market_caution_much_data">Caution: Due to this exchange\'s specification, checking the price on it may consume a lot of mobile data (while on mobile network). Be sure that you understand the possible consequences.</string>
     <string name="market_caution_allcoin">This exchange has a limit of 3000 requests per hour. Make sure you don\'t exceed the limit:)</string>
     <string name="market_caution_yobit">This exchange has a limit of 100 requests per minute. Make sure you don\'t exceed the limit:)</string>
-    <string name="market_caution_dex_coingecko">This is a decentralized exchange (DEX).
-        The price is obtained via the third party resource CoinGecko.com</string>
+    <string name="market_caution_uniswap">This is a decentralized exchange (DEX).
+        The price is obtained via the third party resource TheGraph.com.
+        Only top 500 most liquid pairs are used.</string>
 
 </resources>

--- a/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/CheckerVolleyMainRequest.kt
+++ b/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/CheckerVolleyMainRequest.kt
@@ -11,11 +11,11 @@ import com.aneonex.bitcoinchecker.tester.volley.CheckerVolleyMainRequest.TickerW
 import com.aneonex.bitcoinchecker.tester.volley.generic.GenericCheckerVolleyRequest
 
 class CheckerVolleyMainRequest(market: Market, checkerInfo: CheckerInfo, listener: Response.Listener<TickerWrapper?>, errorListener: Response.ErrorListener)
-    : GenericCheckerVolleyRequest<TickerWrapper?>(market.getUrl(0, checkerInfo), checkerInfo, listener, errorListener) {
+    : GenericCheckerVolleyRequest<TickerWrapper?>(market.getUrl(0, checkerInfo), market.getRequestBody(0, checkerInfo), checkerInfo, listener, errorListener) {
 
     private val market: Market
     @Throws(Exception::class)
-    override fun parseNetworkResponse(headers: Map<String?, String?>?, responseString: String?): TickerWrapper? {
+    override fun parseNetworkResponse(headers: Map<String?, String?>?, responseString: String?): TickerWrapper {
         val tickerWrapper = TickerWrapper()
         try {
             tickerWrapper.ticker = market.parseTickerMain(0, responseString!!, Ticker(), checkerInfo)
@@ -38,8 +38,9 @@ class CheckerVolleyMainRequest(market: Market, checkerInfo: CheckerInfo, listene
                 try {
                     val future = RequestFuture.newFuture<String>()
                     val nextUrl = market.getUrl(requestId, checkerInfo)
+                    val nextRequestBody = market.getRequestBody(requestId, checkerInfo)
                     if (!TextUtils.isEmpty(nextUrl)) {
-                        val request = CheckerVolleyNextRequest(nextUrl, checkerInfo, future)
+                        val request = CheckerVolleyNextRequest(nextUrl, nextRequestBody, checkerInfo, future)
                         requestQueue!!.add(request)
                         val nextResponse = future.get() // this will block
                         market.parseTickerMain(requestId, nextResponse, tickerWrapper.ticker!!, checkerInfo)

--- a/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/CheckerVolleyNextRequest.kt
+++ b/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/CheckerVolleyNextRequest.kt
@@ -4,7 +4,7 @@ import com.android.volley.toolbox.RequestFuture
 import com.aneonex.bitcoinchecker.datamodule.model.CheckerInfo
 import com.aneonex.bitcoinchecker.tester.volley.generic.GenericCheckerVolleyRequest
 
-class CheckerVolleyNextRequest(url: String?, checkerInfo: CheckerInfo, future: RequestFuture<String>) : GenericCheckerVolleyRequest<String?>(url, checkerInfo, future, future) {
+class CheckerVolleyNextRequest(url: String?, requestBody: String?, checkerInfo: CheckerInfo, future: RequestFuture<String>) : GenericCheckerVolleyRequest<String?>(url, requestBody, checkerInfo, future, future) {
     @Throws(Exception::class)
     override fun parseNetworkResponse(headers: Map<String?, String?>?, responseString: String?): String? {
         return responseString

--- a/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/DynamicCurrencyPairsVolleyMainRequest.kt
+++ b/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/DynamicCurrencyPairsVolleyMainRequest.kt
@@ -13,7 +13,7 @@ import com.aneonex.bitcoinchecker.tester.volley.generic.GzipVolleyRequest
 import java.util.*
 
 class DynamicCurrencyPairsVolleyMainRequest(private val context: Context, private val market: Market, listener: Response.Listener<CurrencyPairsMapHelper?>, errorListener: Response.ErrorListener)
-    : GzipVolleyRequest<CurrencyPairsMapHelper?>(market.getCurrencyPairsUrl(0), listener, errorListener) {
+    : GzipVolleyRequest<CurrencyPairsMapHelper?>(market.getCurrencyPairsUrl(0), market.getCurrencyPairsRequestBody(0), listener, errorListener) {
 
     @Throws(Exception::class)
     override fun parseNetworkResponse(headers: Map<String?, String?>?, responseString: String?): CurrencyPairsMapHelper {
@@ -26,8 +26,9 @@ class DynamicCurrencyPairsVolleyMainRequest(private val context: Context, privat
                 try {
                     val future = RequestFuture.newFuture<String>()
                     val nextUrl = market.getCurrencyPairsUrl(requestId)
+                    val nextRequestBody = market.getCurrencyPairsRequestBody(requestId)
                     if (!TextUtils.isEmpty(nextUrl)) {
-                        val request = DynamicCurrencyPairsVolleyNextRequest(nextUrl, future)
+                        val request = DynamicCurrencyPairsVolleyNextRequest(nextUrl, nextRequestBody, future)
                         requestQueue!!.add(request)
                         val nextResponse = future.get() // this will block
                         nextPairs.clear()

--- a/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/DynamicCurrencyPairsVolleyNextRequest.kt
+++ b/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/DynamicCurrencyPairsVolleyNextRequest.kt
@@ -3,7 +3,7 @@ package com.aneonex.bitcoinchecker.tester.volley
 import com.android.volley.toolbox.RequestFuture
 import com.aneonex.bitcoinchecker.tester.volley.generic.GzipVolleyRequest
 
-class DynamicCurrencyPairsVolleyNextRequest(url: String?, future: RequestFuture<String>) : GzipVolleyRequest<String?>(url, future, future) {
+class DynamicCurrencyPairsVolleyNextRequest(url: String?, requestBody: String?, future: RequestFuture<String>) : GzipVolleyRequest<String?>(url, requestBody, future, future) {
     @Throws(Exception::class)
     override fun parseNetworkResponse(headers: Map<String?, String?>?, responseString: String?): String? {
         return responseString

--- a/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/generic/GenericCheckerVolleyRequest.kt
+++ b/dataModuleTester/src/main/java/com/aneonex/bitcoinchecker/tester/volley/generic/GenericCheckerVolleyRequest.kt
@@ -3,4 +3,5 @@ package com.aneonex.bitcoinchecker.tester.volley.generic
 import com.android.volley.Response
 import com.aneonex.bitcoinchecker.datamodule.model.CheckerInfo
 
-abstract class GenericCheckerVolleyRequest<T>(url: String?, protected val checkerInfo: CheckerInfo, listener: Response.Listener<T>, errorListener: Response.ErrorListener) : GzipVolleyRequest<T>(url, listener, errorListener)
+abstract class GenericCheckerVolleyRequest<T>(url: String?, requestBody: String?, protected val checkerInfo: CheckerInfo, listener: Response.Listener<T>, errorListener: Response.ErrorListener)
+    : GzipVolleyRequest<T>(url, requestBody, listener, errorListener)


### PR DESCRIPTION
- Refactored DEX support. HTTP POST requests now allowed, and It allows working with the GraphQL protocol.
- Now using TheGraph.com (over GraphQL protocol) instead of CoinGeko. TheGraph is used by the official Uniswap site http://uniswap.info/.

Issue #30
