### PR TITLE
Binance Futures: fixed duplicate pairs (support perpetual futures only)

### DIFF
--- a/dataModule/src/main/java/com/aneonex/bitcoinchecker/datamodule/model/market/BinanceFutures.kt
+++ b/dataModule/src/main/java/com/aneonex/bitcoinchecker/datamodule/model/market/BinanceFutures.kt
@@ -37,6 +37,10 @@ class BinanceFutures : Market(NAME, TTS_NAME, null) {
         for (i in 0 until jsonSymbols.length()) {
             val marketJsonObject = jsonSymbols.getJSONObject(i)
 
+            // Tha app UI supports only perpetual futures
+            if(marketJsonObject.getString("contractType") != "PERPETUAL")
+                continue
+
             val symbol = marketJsonObject.getString("symbol")
             val baseAsset = marketJsonObject.getString("baseAsset")
             val quoteAsset = marketJsonObject.getString("quoteAsset")


### PR DESCRIPTION
Issue #116 
Fixed duplicate pairs ETH-USDT, BTC-USDT. 
Instead of perpetual futures, were used random periodic futures recently added on Binance.